### PR TITLE
Recognize parameters without parentheses in methods

### DIFF
--- a/src/parsers/definitions/method.ts
+++ b/src/parsers/definitions/method.ts
@@ -15,7 +15,7 @@ export default class MethodDef implements IBaseParser {
       /(?:def)\s+/, // def
       /(?:self)?\.?/, // self.
       /([a-zA-Z_\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf][a-zA-Z_0-9\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]+[!?=]?|\+|-|\*|\*\*|\/|%|&|\^|>>|<<|==|!=|===|=~|!~|<=>|<|<=|>|>=|\[\]=|\[\]|\+@|-@|!@|~@)?/, // method name
-      /(\(.*\))?/, // method parameters
+      /(\(.*\)|[^;].*)?/, // method parameters
     ].map((r) => r.source).join(""),
   );
   // tslint:enable:max-line-length

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -70,6 +70,7 @@ suite("Default Documenter Tests", () => {
     "method/single_line_parentheses",
     "method/initializer",
     "method/class_single_param",
+    "method/without_parentheses",
     "method/naming/setter",
     "method/naming/bang",
     "method/naming/boolean",

--- a/src/test/project/method/without_parentheses.rb
+++ b/src/test/project/method/without_parentheses.rb
@@ -1,0 +1,2 @@
+def foo bar, baz = 1, qux: 2
+end

--- a/src/test/project/method/without_parentheses_expected.rb
+++ b/src/test/project/method/without_parentheses_expected.rb
@@ -1,0 +1,11 @@
+#
+# <Description>
+#
+# @param [<Type>] bar <description>
+# @param [<Type>] baz <description>
+# @param [<Type>] qux <description>
+#
+# @return [<Type>] <description>
+#
+def foo bar, baz = 1, qux: 2
+end


### PR DESCRIPTION
Hopefully fixes #1.

I found that the function that extracts the parameter does a good job, so it was only necessary make the last regex group catch more.

There are still some edge and strange cases that doesn't work, but it's on faulty ruby code like:

```rb
def foo bar, baz quz
end
```

Generating a test like `non_commentable`, stills fails, I guess because of `buildParams()` in [methods.ts](https://github.com/pavlitsky/vscode-yard/blob/fe885442b235eb9a1838e5bdddd8bcdbcab47352/src/parsers/definitions/method.ts#L57).