### PR TITLE
Order of name and type in params documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ os:
   - linux
 
 before_install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
+  - |
+    if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export DISPLAY=':99.0'
+      /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
     fi
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add an configuration option for the `@param` tag to render name-before-type variant,
+  i.e. `@param username [String]` (#7).
+
 ## [0.3.2] - 2019-06-01
 
 - Fix keyboard shortcut for Mac

--- a/README.md
+++ b/README.md
@@ -135,12 +135,8 @@ a curt and verbose documentation styles.
 "yard.spacers.afterTags" // Append an empty line to all method's tags
 "yard.spacers.beforeSingleTag" // Prepend an empty line to directives or single tags (for example constants)
 "yard.spacers.afterSingleTag" // Append an empty line to directives or single tags (for example constants)
-```
-
-Insertion of the `@author` tag can be opted with this setting.
-
-```ts
 "yard.tags.author" // Append @author tag to Class and Module documentation
+"yard.tags.paramNameBeforeType" // Print param name before its type (for example '@param username [String]')
 ```
 
 ## TODO

--- a/package.json
+++ b/package.json
@@ -97,8 +97,13 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Append @author tag to Class and Module documentation"
-                }
-            }
+                },
+                "yard.tags.paramNameBeforeType": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Print param name before its type (for example '@param username [String]')"
+              }
+          }
         }
     },
     "scripts": {

--- a/src/renderers/snippet_string.ts
+++ b/src/renderers/snippet_string.ts
@@ -55,7 +55,7 @@ export class Renderer {
   private directiveEntity(entity: Directive) {
     this.snippet.appendText("@!" + entity.tagName);
     if (entity.tagTypes) { this.typesList(entity.tagTypes); }
-    this.snippet.appendText(" " + entity.name);
+    this.spacer.spacedText(entity.name);
     this.spacer.endOfLine();
     entity.entities.forEach((e) => {
       this.snippet.appendText("  "); // nested entities get two spaces identation
@@ -98,8 +98,13 @@ export class Renderer {
   // @tagName [types] name <description>
   private tagWithTypesEntity(entity: TagWithTypes) {
     this.snippet.appendText("@" + entity.tagName);
-    this.typesList(entity.types);
-    if (entity.name) { this.snippet.appendText(" " + entity.name); }
+    if (this.config.get("paramNameBeforeType")) {
+      this.spacer.spacedText(entity.name);
+      this.typesList(entity.types);
+    } else {
+      this.typesList(entity.types);
+      this.spacer.spacedText(entity.name);
+    }
     this.snippet.appendText(" ");
     this.textOrPlaceholder(entity.text, "<description>");
     this.spacer.endOfLine();

--- a/src/renderers/snippet_string.ts
+++ b/src/renderers/snippet_string.ts
@@ -54,7 +54,7 @@ export class Renderer {
   //   @return [<Type>] <description>
   private directiveEntity(entity: Directive) {
     this.snippet.appendText("@!" + entity.tagName);
-    if (entity.tagTypes) { this.snippet.appendText(" [" + entity.tagTypes + "]"); }
+    if (entity.tagTypes) { this.typesList(entity.tagTypes); }
     this.snippet.appendText(" " + entity.name);
     this.spacer.endOfLine();
     entity.entities.forEach((e) => {
@@ -77,9 +77,9 @@ export class Renderer {
   // Render an @option tag line
   // @option paramName [types] :<key> <description>
   private tagOptionEntity(entity: TagOption) {
-    this.snippet.appendText("@option " + entity.paramName + " [");
-    this.textOrPlaceholder(entity.types, "<Type>");
-    this.snippet.appendText("] :");
+    this.snippet.appendText("@option " + entity.paramName);
+    this.typesList(entity.types);
+    this.snippet.appendText(" :");
     this.textOrPlaceholder(entity.key, "<key>");
     this.snippet.appendText(" ");
     this.textOrPlaceholder(entity.text, "<description>");
@@ -97,10 +97,10 @@ export class Renderer {
   // Render a tag with a types line
   // @tagName [types] name <description>
   private tagWithTypesEntity(entity: TagWithTypes) {
-    this.snippet.appendText("@" + entity.tagName + " [");
-    this.textOrPlaceholder(entity.types, "<Type>");
-    this.snippet.appendText("] ");
-    if (entity.name) { this.snippet.appendText(entity.name + " "); }
+    this.snippet.appendText("@" + entity.tagName);
+    this.typesList(entity.types);
+    if (entity.name) { this.snippet.appendText(" " + entity.name); }
+    this.snippet.appendText(" ");
     this.textOrPlaceholder(entity.text, "<description>");
     this.spacer.endOfLine();
   }
@@ -119,6 +119,14 @@ export class Renderer {
     } else {
       this.snippet.appendPlaceholder(placeholder);
     }
+  }
+
+  // Render entity types list
+  // [types]
+  private typesList(types: string) {
+    this.snippet.appendText(" [");
+    this.textOrPlaceholder(types, "<Type>");
+    this.snippet.appendText("]");
   }
 
   // Decorate the snippet and return a rebuilt one.

--- a/src/renderers/snippet_string/spacer_helper.ts
+++ b/src/renderers/snippet_string/spacer_helper.ts
@@ -55,6 +55,11 @@ export class SpacerHelper {
     }
   }
 
+  // Append spaced string
+  public spacedText(text: string) {
+    if (text) { this.snippet.appendText(" " + text); }
+  }
+
   // Append empty line to a snippet
   public endOfLine() {
     this.snippet.appendText(this.eol);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -153,6 +153,32 @@ suite("Curt Documenter Tests", () => {
   expectDocumented(testCases);
 });
 
+suite("Special options", () => {
+  const configOptions = {
+    spacers: {
+      afterDescription: true,
+      afterSingleTag: false,
+      afterTags: true,
+      beforeDescription: true,
+      beforeSingleTag: false,
+      beforeTags: true,
+      separateTags: true,
+    },
+    tags: {
+      author: true,
+      paramNameBeforeType: true, // Non default
+    },
+  };
+
+  const testCases = [
+    "special/param_name_before_types"
+  ];
+
+  suiteSetup(async () => { await updateConfig(configOptions); });
+  expectDocumented(testCases);
+});
+
+
 suite("Extension Tests", () => {
   test("should be present", () => {
     assert.ok(extensions.getExtension(extensionID));

--- a/src/test/project/special/param_name_before_types.rb
+++ b/src/test/project/special/param_name_before_types.rb
@@ -1,0 +1,2 @@
+def foo(bar)
+end

--- a/src/test/project/special/param_name_before_types_expected.rb
+++ b/src/test/project/special/param_name_before_types_expected.rb
@@ -1,0 +1,9 @@
+#
+# <Description>
+#
+# @param bar [<Type>] <description>
+#
+# @return [<Type>] <description>
+#
+def foo(bar)
+end


### PR DESCRIPTION
Add a configuration option for the `@param` tag to render the name-before-type variant.

When `yard.tags.paramNameBeforeType` option is set to `true` it renders:
```
@param username [String] User name
```
